### PR TITLE
fix: replace match route type

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -10,6 +10,18 @@ export function NavLink(props: NavLinkProps) {
     const location = useLocation();
 
     function onClick(event: MouseEvent) {
+        // Allow default behavior of opening link in new tab etc.
+        if (
+            props.target === "_blank" ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.altKey ||
+            event.shiftKey ||
+            event.button !== 0
+        ) {
+            return;
+        }
+
         event.preventDefault();
 
         onNavigate(props.href);

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,7 +1,9 @@
 import type { JSX } from "preact";
 import { useHistory, useLocation, useMatch } from "..";
 
-export interface NavLinkProps extends JSX.HTMLAttributes<HTMLAnchorElement> {}
+export interface NavLinkProps extends JSX.HTMLAttributes<HTMLAnchorElement> {
+    activeClassName?: string;
+}
 
 export function NavLink(props: NavLinkProps) {
     const history = useHistory();
@@ -20,12 +22,20 @@ export function NavLink(props: NavLinkProps) {
         window.dispatchEvent(new Event("popstate"));
     }
 
-    // Apply type="active" when current url matches route
-    if (props.href && useMatch(props.href, location.pathname) !== null) {
-        if (props.type) props.type += " ";
+    const isActive =
+        props.href && useMatch(props.href, location.pathname) !== null;
 
-        props.type += "active";
-    }
-
-    return <a {...props} onClick={onClick} />;
+    return (
+        <a
+            {...props}
+            // Apply activeClassName when current url matches route
+            className={[
+                props.className && props.className,
+                isActive && props.activeClassName,
+            ]
+                .filter((e) => !!e)
+                .join(" ")}
+            onClick={onClick}
+        />
+    );
 }


### PR DESCRIPTION
I tested different preact router and would like to use yours in my project. Thanks for making it. 

I like to contribute a fix, related to the `active` url matches. The `types` attribute is used for [the media type of the linked page](https://www.dofactory.com/html/a/type#using).

- With the fix we can specify an optional `activeClassName` string. It will be added to the `props.className` then.
- I also added the feature to: Allow default behavior of opening link in new tab etc.